### PR TITLE
docs: add links to third-party datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,25 @@ You can download the dataset:
   - [ITLP Campus Outdoor](https://huggingface.co/datasets/OPR-Project/ITLP-Campus-Outdoor)
   - [ITLP Campus Indoor](https://huggingface.co/datasets/OPR-Project/ITLP-Campus-Indoor)
 
+## Other Datasets
+
+We provide several datasets that can be used with the library.
+
+- [Oxford RobotCar](https://robotcar-dataset.robots.ox.ac.uk/) is a comprehensive autonomous driving dataset
+  featuring over 1,000 km of traffic data, nearly 20 million images, and sensor data collected in diverse weather conditions
+  from an autonomous vehicle in Oxford between 2014 and 2015.
+  We provide a specifically pre-processed subset designed for the place recognition task in the OpenPlaceRecognition library.
+  This subset is primarily based on the
+  [PointNetVLAD paper](https://openaccess.thecvf.com/content_cvpr_2018/html/Uy_PointNetVLAD_Deep_Point_CVPR_2018_paper.html).
+  - [Hugging Face](https://huggingface.co/datasets/OPR-Project/OxfordRobotCar_OpenPlaceRecognition)
+  - [Kaggle](https://www.kaggle.com/datasets/creatorofuniverses/oxfordrobotcar-iprofi-hack-23)
+
+- [NCLT](https://robots.engin.umich.edu/nclt/index.html#top) is the University of Michigan North Campus Long-Term Vision and LIDAR Dataset.
+  We provide a modified version of the NCLT dataset, which is primarily based on the
+  [AdaFusion paper](https://ieeexplore.ieee.org/abstract/document/9905898/).
+  - [Hugging Face](https://huggingface.co/datasets/OPR-Project/NCLT_OpenPlaceRecognition)
+  - [Kaggle](https://www.kaggle.com/datasets/creatorofuniverses/nclt-iprofi-hack-23)
+
 ## Package Structure
 
 You can learn more about the package structure in the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -260,6 +260,29 @@ and consists of tracks recorded at different times of day (day/dusk/night) and d
 You can find more details in the `OPR-Project/ITLP-Campus <https://github.com/OPR-Project/ITLP-Campus>`_ repository.
 
 
+Other datasets
+==============
+
+We provide several datasets that can be used with the library.
+
+* `Oxford RobotCar <https://robotcar-dataset.robots.ox.ac.uk/>`_ is a comprehensive autonomous driving dataset
+  featuring over 1,000 km of traffic data, nearly 20 million images, and sensor data collected in diverse weather conditions
+  from an autonomous vehicle in Oxford between 2014 and 2015.
+  We provide a specifically pre-processed subset designed for the place recognition task in the OpenPlaceRecognition library.
+  This subset is primarily based on the
+  `PointNetVLAD paper <https://openaccess.thecvf.com/content_cvpr_2018/html/Uy_PointNetVLAD_Deep_Point_CVPR_2018_paper.html>`_.
+
+  * `Hugging Face <https://huggingface.co/datasets/OPR-Project/OxfordRobotCar_OpenPlaceRecognition>`_
+  * `Kaggle <https://www.kaggle.com/datasets/creatorofuniverses/oxfordrobotcar-iprofi-hack-23>`_
+
+* `NCLT <https://robots.engin.umich.edu/nclt/index.html#top>`_ is the University of Michigan North Campus Long-Term Vision and LIDAR Dataset.
+  We provide a modified version of the NCLT dataset, which is primarily based on the
+  `AdaFusion paper <https://ieeexplore.ieee.org/abstract/document/9905898/>`_.
+
+  * `Hugging Face <https://huggingface.co/datasets/OPR-Project/NCLT_OpenPlaceRecognition>`_
+  * `Kaggle <https://www.kaggle.com/datasets/creatorofuniverses/nclt-iprofi-hack-23>`_
+
+
 Package Structure
 =================
 

--- a/docs/source/locale/ru/LC_MESSAGES/index.po
+++ b/docs/source/locale/ru/LC_MESSAGES/index.po
@@ -500,6 +500,81 @@ msgstr ""
 "`OPR-Project/ITLP-Campus <https://github.com/OPR-Project/ITLP-Campus>`_."
 
 #: ../../source/index.rst:264
+msgid "Other datasets"
+msgstr "Другие датасеты"
+
+#: ../../source/index.rst:266
+msgid "We provide several datasets that can be used with the library."
+msgstr "Мы предоставляем несколько наборов данных, которые можно использовать с библиотекой."
+
+#: ../../source/index.rst:268
+msgid ""
+"`Oxford RobotCar <https://robotcar-dataset.robots.ox.ac.uk/>`_ is a "
+"comprehensive autonomous driving dataset featuring over 1,000 km of traffic "
+"data, nearly 20 million images, and sensor data collected in diverse weather "
+"conditions from an autonomous vehicle in Oxford between 2014 and 2015. We "
+"provide a specifically pre-processed subset designed for the place "
+"recognition task in the OpenPlaceRecognition library. This subset is "
+"primarily based on the `PointNetVLAD paper <https://openaccess.thecvf.com/"
+"content_cvpr_2018/html/Uy_PointNetVLAD_Deep_Point_CVPR_2018_paper.html>`_."
+msgstr ""
+"`Oxford RobotCar <https://robotcar-dataset.robots.ox.ac.uk/>`_ — это "
+"обширный набор данных для автономного вождения, содержащий более 1000 км "
+"данных о дорожном движении, около 20 миллионов изображений и данные с "
+"датчиков, собранные в различных погодных условиях с автономного "
+"транспортного средства в Оксфорде в период с 2014 по 2015 год. Мы "
+"предоставляем специально предварительно обработанный поднабор, "
+"предназначенный для задачи распознавания мест в библиотеке "
+"OpenPlaceRecognition. Этот поднабор в основном основан на статье `PointNetVLAD "
+"<https://openaccess.thecvf.com/content_cvpr_2018/html/Uy_PointNetVLAD_Deep_"
+"Point_CVPR_2018_paper.html>`_."
+
+#: ../../source/index.rst:275
+msgid ""
+"`Hugging Face <https://huggingface.co/datasets/OPR-Project/"
+"OxfordRobotCar_OpenPlaceRecognition>`_"
+msgstr ""
+"`Hugging Face <https://huggingface.co/datasets/OPR-Project/"
+"OxfordRobotCar_OpenPlaceRecognition>`_"
+
+#: ../../source/index.rst:276
+msgid ""
+"`Kaggle <https://www.kaggle.com/datasets/creatorofuniverses/oxfordrobotcar-"
+"iprofi-hack-23>`_"
+msgstr ""
+"`Kaggle <https://www.kaggle.com/datasets/creatorofuniverses/oxfordrobotcar-"
+"iprofi-hack-23>`_"
+
+#: ../../source/index.rst:278
+msgid ""
+"`NCLT <https://robots.engin.umich.edu/nclt/index.html#top>`_ is the "
+"University of Michigan North Campus Long-Term Vision and LIDAR Dataset. We "
+"provide a modified version of the NCLT dataset, which is primarily based on "
+"the `AdaFusion paper <https://ieeexplore.ieee.org/abstract/document/9905898/"
+">`_."
+msgstr ""
+"`NCLT <https://robots.engin.umich.edu/nclt/index.html#top>`_ — это набор "
+"данных University of Michigan North Campus Long-Term Vision and LIDAR Dataset. "
+"Мы предоставляем изменённую версию набора данных NCLT, основанную в основном "
+"на статье `AdaFusion <https://ieeexplore.ieee.org/abstract/document/9905898/>`_."
+
+#: ../../source/index.rst:282
+msgid ""
+"`Hugging Face <https://huggingface.co/datasets/OPR-Project/"
+"NCLT_OpenPlaceRecognition>`_"
+msgstr ""
+"`Hugging Face <https://huggingface.co/datasets/OPR-Project/"
+"NCLT_OpenPlaceRecognition>`_"
+
+#: ../../source/index.rst:283
+msgid ""
+"`Kaggle <https://www.kaggle.com/datasets/creatorofuniverses/nclt-iprofi-"
+"hack-23>`_"
+msgstr ""
+"`Kaggle <https://www.kaggle.com/datasets/creatorofuniverses/nclt-iprofi-"
+"hack-23>`_"
+
+#: ../../source/index.rst:287
 msgid "Package Structure"
 msgstr "Структура пакета"
 


### PR DESCRIPTION
This pull request updates the documentation to include information about additional datasets that can be used with the library. The most important changes are the additions of comprehensive descriptions and links to the Oxford RobotCar and NCLT datasets in both the `README.md` and `index.rst` files.

Updates to documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142-R160): Added a new section "Other Datasets" with descriptions and links to the Oxford RobotCar and NCLT datasets.
* [`docs/source/index.rst`](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fR263-R285): Added a new section "Other datasets" with descriptions and links to the Oxford RobotCar and NCLT datasets.