### PR TITLE
docs: add links to NCLT dataset pages

### DIFF
--- a/notebooks/test_update_pointcloud_reg_pipe.ipynb
+++ b/notebooks/test_update_pointcloud_reg_pipe.ipynb
@@ -82,6 +82,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Dataset source\n",
+    "\n",
+    "[NCLT](https://robots.engin.umich.edu/nclt/index.html#top) is the University of\n",
+    "Michigan North Campus Long-Term Vision and LIDAR Dataset.\n",
+    "We provide a modified version of the NCLT dataset, which is primarily based on the\n",
+    "[AdaFusion paper](https://ieeexplore.ieee.org/abstract/document/9905898/).\n",
+    "\n",
+    "- [Hugging Face](https://huggingface.co/datasets/OPR-Project/NCLT_OpenPlaceRecognition)\n",
+    "- [Kaggle](https://www.kaggle.com/datasets/creatorofuniverses/nclt-iprofi-hack-23)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Weights download\n",
     "\n",
     "##### Place Recognition\n",


### PR DESCRIPTION
This pull request includes updates to two Jupyter notebooks to add dataset source information and make minor adjustments to execution counts.

Dataset source information added:

* [`notebooks/test_update_pointcloud_reg_pipe.ipynb`](diffhunk://#diff-ebcd07ea349db15defe6e0e486c7ff90e9d116a1835dae78b6ef40063881cf39R81-R95): Added a markdown cell with information about the NCLT dataset and links to Hugging Face and Kaggle.
* [`notebooks/vis_image_mask_text.ipynb`](diffhunk://#diff-567b219e88b6b56cd093e50e890bb87f905b6ef71d57efe83aca8d4a71c0a8e9R28-R45): Added a markdown cell with information about the NCLT dataset and links to Hugging Face and Kaggle.

Minor adjustments to execution counts:

* [`notebooks/vis_image_mask_text.ipynb`](diffhunk://#diff-567b219e88b6b56cd093e50e890bb87f905b6ef71d57efe83aca8d4a71c0a8e9L17-R17): Changed the `execution_count` of multiple code cells to `null`. [[1]](diffhunk://#diff-567b219e88b6b56cd093e50e890bb87f905b6ef71d57efe83aca8d4a71c0a8e9L17-R17) [[2]](diffhunk://#diff-567b219e88b6b56cd093e50e890bb87f905b6ef71d57efe83aca8d4a71c0a8e9L79-R94)